### PR TITLE
Fix #7

### DIFF
--- a/src/main/java/com/rationalagents/twbxless/Application.java
+++ b/src/main/java/com/rationalagents/twbxless/Application.java
@@ -8,7 +8,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class Application {
 
 	public static void main(String[] args) {
-		SpringApplication app = new SpringApplication(Application.class);
+		var app = new SpringApplication(Application.class);
 		app.setBannerMode(Banner.Mode.OFF);
 		app.run(args);
 	}

--- a/src/main/java/com/rationalagents/twbxless/Controller.java
+++ b/src/main/java/com/rationalagents/twbxless/Controller.java
@@ -29,7 +29,7 @@ public class Controller {
 
 	@RequestMapping(value="datasources", method = RequestMethod.GET, produces="text/plain")
 	public String getDataSources(@RequestParam String url) {
-		List<List<String>> result = new ArrayList<>();
+		var result = new ArrayList<List<String>>();
 		result.add(List.of("name", "filename"));
 		hyperService.getDataSources(url).forEach((k, v) -> result.add(List.of(k, v)));
 		return Csv.toCsv(result);
@@ -37,7 +37,6 @@ public class Controller {
 
 	@RequestMapping(value="data", method = RequestMethod.GET, produces="text/plain", params = {"url", "filename"})
 	public String getDataByFilename(@RequestParam String url, @RequestParam String filename) {
-
 		try {
 			return Csv.toCsv(hyperService.getDataByFilename(url, filename));
 		} catch (DataException e) {
@@ -47,7 +46,6 @@ public class Controller {
 
 	@RequestMapping(value="data", method = RequestMethod.GET, produces="text/plain", params = {"url", "name"})
 	public String getDataByName(@RequestParam String url, @RequestParam String name) {
-
 		try {
 			return Csv.toCsv(hyperService.getDataByName(url, name));
 		} catch (DataException e) {
@@ -60,7 +58,7 @@ public class Controller {
 	 */
 	private static class Csv {
 		static String toCsv(String singleHeader, List<String> singleColumn) {
-			List<List<String>> list = new ArrayList<>();
+			var list = new ArrayList<List<String>>();
 			list.add(List.of(singleHeader));
 			singleColumn.forEach(v -> list.add(List.of(v)));
 			return toCsv(list);
@@ -71,8 +69,8 @@ public class Controller {
 		}
 
 		static String toCsv(List<List<String>> rows) {
-			StringWriter writer = new StringWriter();
-			CsvListWriter csvWriter = new CsvListWriter(writer, CsvPreference.STANDARD_PREFERENCE);
+			var writer = new StringWriter();
+			var csvWriter = new CsvListWriter(writer, CsvPreference.STANDARD_PREFERENCE);
 
 			try {
 				for (List<String> row : rows) {

--- a/src/main/java/com/rationalagents/twbxless/Controller.java
+++ b/src/main/java/com/rationalagents/twbxless/Controller.java
@@ -12,6 +12,8 @@ import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 
+import static java.util.stream.Collectors.toList;
+
 @RestController
 public class Controller {
 
@@ -24,6 +26,14 @@ public class Controller {
 	@RequestMapping(value="filenames", method = RequestMethod.GET, produces="text/plain")
 	public String getFilenames(@RequestParam String url) {
 		return Csv.toCsv("filenames", hyperService.getFilenames(url));
+	}
+
+	@RequestMapping(value="datasources", method = RequestMethod.GET, produces="text/plain")
+	public String getDataSources(@RequestParam String url) {
+		List<List<String>> result = new ArrayList<>();
+		result.add(List.of("caption", "filename"));
+		result.addAll(hyperService.getDataSources(url).stream().map(v -> List.of(v.caption, v.filename)).collect(toList()));
+		return Csv.toCsv(result);
 	}
 
 	@RequestMapping(value="data", method = RequestMethod.GET, produces="text/plain")

--- a/src/main/java/com/rationalagents/twbxless/Controller.java
+++ b/src/main/java/com/rationalagents/twbxless/Controller.java
@@ -10,6 +10,7 @@ import org.supercsv.prefs.CsvPreference;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 @RestController
@@ -34,11 +35,21 @@ public class Controller {
 		return Csv.toCsv(result);
 	}
 
-	@RequestMapping(value="data", method = RequestMethod.GET, produces="text/plain")
-	public String getData(@RequestParam String url, @RequestParam String filename) {
+	@RequestMapping(value="data", method = RequestMethod.GET, produces="text/plain", params = {"url", "filename"})
+	public String getDataByFilename(@RequestParam String url, @RequestParam String filename) {
 
 		try {
-			return Csv.toCsv(hyperService.getData(url, filename));
+			return Csv.toCsv(hyperService.getDataByFilename(url, filename));
+		} catch (DataException e) {
+			return Csv.toCsv(e);
+		}
+	}
+
+	@RequestMapping(value="data", method = RequestMethod.GET, produces="text/plain", params = {"url", "name"})
+	public String getDataByName(@RequestParam String url, @RequestParam String name) {
+
+		try {
+			return Csv.toCsv(hyperService.getDataByName(url, name));
 		} catch (DataException e) {
 			return Csv.toCsv(e);
 		}

--- a/src/main/java/com/rationalagents/twbxless/Controller.java
+++ b/src/main/java/com/rationalagents/twbxless/Controller.java
@@ -12,8 +12,6 @@ import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 
-import static java.util.stream.Collectors.toList;
-
 @RestController
 public class Controller {
 
@@ -31,8 +29,8 @@ public class Controller {
 	@RequestMapping(value="datasources", method = RequestMethod.GET, produces="text/plain")
 	public String getDataSources(@RequestParam String url) {
 		List<List<String>> result = new ArrayList<>();
-		result.add(List.of("caption", "filename"));
-		result.addAll(hyperService.getDataSources(url).stream().map(v -> List.of(v.caption, v.filename)).collect(toList()));
+		result.add(List.of("name", "filename"));
+		hyperService.getDataSources(url).forEach((k, v) -> result.add(List.of(k, v)));
 		return Csv.toCsv(result);
 	}
 

--- a/src/main/java/com/rationalagents/twbxless/DataException.java
+++ b/src/main/java/com/rationalagents/twbxless/DataException.java
@@ -1,14 +1,15 @@
 package com.rationalagents.twbxless;
 
+import java.util.Collection;
 import java.util.List;
 
 public class DataException extends RuntimeException {
 
 	private final List<String> extraData;
 
-	public DataException(String message, List<String> extraData) {
+	public DataException(String message, Collection<String> extraData) {
 		super(message);
-		this.extraData = extraData;
+		this.extraData = List.copyOf(extraData);
 	}
 
 	public List<String> getExtraData() {

--- a/src/main/java/com/rationalagents/twbxless/FileUtils.java
+++ b/src/main/java/com/rationalagents/twbxless/FileUtils.java
@@ -18,15 +18,14 @@ public class FileUtils {
 	 * returning the the full path to the file.
 	 */
 	public static String extractFile(ZipInputStream zis) throws IOException {
-		File file = File.createTempFile("twbxless-", "");
-
-		FileOutputStream fos = new FileOutputStream(file);
+		var file = File.createTempFile("twbxless-", "");
+		var outputStream = new FileOutputStream(file);
 		int len;
 		byte[] buffer = new byte[1024];
 		while ((len = zis.read(buffer)) > 0) {
-			fos.write(buffer, 0, len);
+			outputStream.write(buffer, 0, len);
 		}
-		fos.close();
+		outputStream.close();
 
 		return file.getAbsolutePath();
 	}

--- a/src/main/java/com/rationalagents/twbxless/HyperService.java
+++ b/src/main/java/com/rationalagents/twbxless/HyperService.java
@@ -64,13 +64,13 @@ public class HyperService {
 			try (FileInputStream stream =  new FileInputStream(extractedTwb)) {
 				Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(stream);
 				NodeList extracts = (NodeList)XPathFactory.newInstance().newXPath()
-					.evaluate("//extract/connection" , doc, XPathConstants.NODESET);
+					.evaluate("//extract/connection[@dbname]" , doc, XPathConstants.NODESET);
 
 				for (int i = 0; i < extracts.getLength(); i++) {
 					Node extractNode = extracts.item(i);
-					String filename = extractNode.getAttributes().getNamedItem("dbname").getNodeValue();
-					String caption = extractNode.getParentNode().getParentNode().getAttributes().getNamedItem("caption").getNodeValue();
-					result.add(new DataSource(caption, filename));
+					String filename = getValueOrNull(extractNode, "dbname");
+					String caption = getValueOrNull(extractNode.getParentNode().getParentNode(), "caption");
+					result.add(new DataSource(caption == null ? "?" : caption, filename));
 				}
 
 				return result;
@@ -80,6 +80,11 @@ public class HyperService {
 		} finally {
 			tryDeleteFile(extractedTwb);
 		}
+	}
+
+	private String getValueOrNull(Node node, String attributeName) {
+		Node attribute = node.getAttributes().getNamedItem(attributeName);
+		return attribute == null ? null : attribute.getNodeValue();
 	}
 
 	public static class DataSource {

--- a/src/main/java/com/rationalagents/twbxless/HyperService.java
+++ b/src/main/java/com/rationalagents/twbxless/HyperService.java
@@ -91,19 +91,29 @@ public class HyperService {
 		return attribute == null ? null : attribute.getNodeValue();
 	}
 
+	public List<List<String>> getDataByName(String url, String name) {
+		Map<String,String> dataSources = getDataSources(url);
+
+		if (!dataSources.containsKey(name)) {
+			throw new DataException("No name match, valid names follow" , dataSources.keySet());
+		}
+
+		return getDataByFilename(url, dataSources.get(name));
+	}
+
 	/**
 	 * Returns data for specified filename within URL.
 	 *
-	 * For convenience (because filenames seem pseudo-random, trying to work out an alternative),
-	 * it goes with first ends-with match.
+	 * The first file that is an ends-with match with filename will be used, since the filenames can be rather long
+	 * with a redundant path part.
 	 */
-	public List<List<String>> getData(String url, String fileName) {
+	public List<List<String>> getDataByFilename(String url, String fileName) {
 
 		String extractedFileName = extract(url, (name) -> {
 			return name.endsWith(".hyper") && name.endsWith(fileName); /* allow ends-with to match */
 		});
 		if (extractedFileName == null) {
-			throw new DataException("No file matching", List.of(fileName));
+			throw new DataException("No file match", List.of(fileName));
 		}
 
 		try {

--- a/src/main/java/com/rationalagents/twbxless/HyperService.java
+++ b/src/main/java/com/rationalagents/twbxless/HyperService.java
@@ -21,6 +21,7 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -51,7 +52,10 @@ public class HyperService {
 		return result;
 	}
 
-	public List<DataSource> getDataSources(String url) {
+	/**
+	 * Returns map of datasource name to filename. If no name, just uses filename.
+	 */
+	public Map<String,String> getDataSources(String url) {
 
 		String extractedTwb = extract(url, (name) -> name.endsWith(".twb"));
 		if (extractedTwb == null) {
@@ -59,7 +63,7 @@ public class HyperService {
 		}
 
 		try {
-			List<DataSource> result = new ArrayList<>();
+			Map<String,String> result = new HashMap<>();
 
 			try (FileInputStream stream =  new FileInputStream(extractedTwb)) {
 				Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(stream);
@@ -70,7 +74,7 @@ public class HyperService {
 					Node extractNode = extracts.item(i);
 					String filename = getValueOrNull(extractNode, "dbname");
 					String caption = getValueOrNull(extractNode.getParentNode().getParentNode(), "caption");
-					result.add(new DataSource(caption == null ? "?" : caption, filename));
+					result.put(caption == null ? filename : caption, filename);
 				}
 
 				return result;
@@ -85,15 +89,6 @@ public class HyperService {
 	private String getValueOrNull(Node node, String attributeName) {
 		Node attribute = node.getAttributes().getNamedItem(attributeName);
 		return attribute == null ? null : attribute.getNodeValue();
-	}
-
-	public static class DataSource {
-		public String caption;
-		public String filename;
-		public DataSource(String caption, String filename) {
-			this.caption = caption;
-			this.filename = filename;
-		}
 	}
 
 	/**

--- a/src/test/java/com/rationalagents/twbxless/EndToEndTest.java
+++ b/src/test/java/com/rationalagents/twbxless/EndToEndTest.java
@@ -33,8 +33,8 @@ public class EndToEndTest {
 	}
 
 	@Test
-	public void canGetDataSources() {
-		assertEquals("caption,filename\r\nData Source 1,Data/TableauTemp/TEMP_0kf7uk81qi1qyf18sg86d1m8pl9s.hyper\r\n",
+	public void getDataSources() {
+		assertEquals("name,filename\r\nData Source 1,Data/TableauTemp/TEMP_0kf7uk81qi1qyf18sg86d1m8pl9s.hyper\r\n",
 			restTemplate.getForObject("http://localhost:" + port + "/datasources?url=classpath:animal-observations.twbx",
 				String.class));
 	}

--- a/src/test/java/com/rationalagents/twbxless/EndToEndTest.java
+++ b/src/test/java/com/rationalagents/twbxless/EndToEndTest.java
@@ -33,6 +33,13 @@ public class EndToEndTest {
 	}
 
 	@Test
+	public void canGetDataSources() {
+		assertEquals("caption,filename\r\nData Source 1,Data/TableauTemp/TEMP_0kf7uk81qi1qyf18sg86d1m8pl9s.hyper\r\n",
+			restTemplate.getForObject("http://localhost:" + port + "/datasources?url=classpath:animal-observations.twbx",
+				String.class));
+	}
+
+	@Test
 	public void canGetData() {
 		assertThat(
 			restTemplate.getForObject("http://localhost:" + port + "/data?url=classpath:animal-observations.twbx"
@@ -40,6 +47,8 @@ public class EndToEndTest {
 			.contains("Date,Animal Observed,Animal,Leg Count\r\n")
 			.contains("2020-05-15,Frog,Frog,4\r\n");
 	}
+
+
 
 	@Test
 	public void issue1CsvEncoding() throws IOException {

--- a/src/test/java/com/rationalagents/twbxless/EndToEndTest.java
+++ b/src/test/java/com/rationalagents/twbxless/EndToEndTest.java
@@ -40,14 +40,22 @@ public class EndToEndTest {
 	}
 
 	@Test
-	public void canGetData() {
+	public void canGetDataByName() {
+		assertThat(
+			restTemplate.getForObject("http://localhost:" + port + "/data?url=classpath:animal-observations.twbx"
+				+ "&name=Data Source 1", String.class))
+			.contains("Date,Animal Observed,Animal,Leg Count\r\n")
+			.contains("2020-05-15,Frog,Frog,4\r\n");
+	}
+
+	@Test
+	public void canGetDataByFilename() {
 		assertThat(
 			restTemplate.getForObject("http://localhost:" + port + "/data?url=classpath:animal-observations.twbx"
 				+ "&filename=Data/TableauTemp/TEMP_0kf7uk81qi1qyf18sg86d1m8pl9s.hyper", String.class))
 			.contains("Date,Animal Observed,Animal,Leg Count\r\n")
 			.contains("2020-05-15,Frog,Frog,4\r\n");
 	}
-
 
 
 	@Test

--- a/src/test/java/com/rationalagents/twbxless/HyperServiceTest.java
+++ b/src/test/java/com/rationalagents/twbxless/HyperServiceTest.java
@@ -18,12 +18,21 @@ public class HyperServiceTest {
 	HyperService service;
 
 	@Test
-	public void expectExceptionIfMissingFilename() {
+	public void expectExceptionDataIfWrongFilename() {
 		DataException thrown = assertThrows(DataException.class,
-			() -> service.getData("https://public.tableau.com/workbooks/Example_15896654403480.twb", "DNE.hyper"));
+			() -> service.getDataByFilename("https://public.tableau.com/workbooks/Example_15896654403480.twb", "DNE.hyper"));
 
-		assertEquals("No file matching", thrown.getMessage());
+		assertEquals("No file match", thrown.getMessage());
 		assertEquals(List.of("DNE.hyper"), thrown.getExtraData());
+	}
+
+	@Test
+	public void expectExceptionDataIfWrongName() {
+		DataException thrown = assertThrows(DataException.class,
+			() -> service.getDataByName("https://public.tableau.com/workbooks/Example_15896654403480.twb", "DNE"));
+
+		assertEquals("No name match, valid names follow", thrown.getMessage());
+		assertEquals(List.of("Data Source 1"), thrown.getExtraData());
 	}
 
 	@Test
@@ -34,7 +43,7 @@ public class HyperServiceTest {
 		assertEquals("url must start with https://public.tableau.com/", thrown.getMessage());
 
 		thrown = assertThrows(RuntimeException.class,
-			() -> service.getData("https://badstuff.com", "doesntmatter"));
+			() -> service.getDataByFilename("https://badstuff.com", "doesntmatter"));
 
 		assertEquals("url must start with https://public.tableau.com/", thrown.getMessage());
 	}


### PR DESCRIPTION
There's now a version of /data with url & name parameters, name as an alternative to filename. This allows you to send the name shown in Tableau Public desktop for the data source, and it'll look up the .hyper extract.

There's also /datasources?url which allows you to see all the data source names (and corresponding filename, if you care about that.)

This is a pretty important improvement because I've seen a couple Tableau files with .hyper filenames that seem to randomly change on publish. This way, unless the publisher decides to rename the data source, you won't have to worry about that.