### PR TITLE
Resolve #9

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,16 +37,6 @@ If so, you're ready to move on to **Use.**
 
 Ctrl+C will stop the container once you're done with it.
 
-## Config (optional)
-
-twbxless supports 3 configuration environment variables:
-
-**PORT**: lingua franca in servlerless, the port to bind to (default is `8080`)
-
-**HYPEREXEC**: path to the executables (e.g. hyperd or hyperd.exe) packaged with Hyper API (default is `/hyperapi/lib/hyper` since that's where [Dockerfile](Dockerfile) puts them)
-
-**URLPREFIX**: required prefix for any URL retrieved (default is `https://public.tableau.com/`)
-
 ## Use
 
 First you'll need to identify the data extracts within a .twbx that's published on the web. To do that,
@@ -85,6 +75,16 @@ Total,2002,male,201,0.931,0
 Total,2003,female,16,0.076,0
 ...
 ```
+## FAQ
+
+### Does twbxless provide access to the external data sources used to make a workbook?
+
+No. It only reads the data that's directly in the .twbx file.
+
+### Does Google Sheets' IMPORTDATA work with http:<nolink>//localhost:8080 URLs?
+
+No, Google Sheets IMPORTDATA needs twbxless to be accessible from the internet. Run twbxless from some serverless somewhere,
+e.g. Google Cloud Run, Azure Containers, AWS, or Heroku, instead of on your computer.
 
 ## Enhancements & limitations
 
@@ -98,20 +98,19 @@ data source), but never a workbook where there was >1 schema/table in a file.  I
 know which file has the data you want! It'd be nice to improve on that. If interested please
 [stop by enhancement #7](/../../issues/7).
 
-## FAQ
+## Configuring twbxless (optional)
 
-### Does twbxless provide access to the external data sources used to make a workbook?
+twbxless supports 3 configuration environment variables.
 
-No. It only reads the data that's directly in the .twbx file.
+**URLPREFIX**: required prefix for any URL retrieved (default is `https://public.tableau.com/`)
 
-### Does Google Sheets' IMPORTDATA work with http:<nolink>//localhost:8080 URLs?
+**HYPEREXEC**: path to the executables (e.g. hyperd or hyperd.exe) packaged with Hyper API (default is `/hyperapi/lib/hyper` since that's where [Dockerfile](Dockerfile) puts them)
 
-No, Google Sheets IMPORTDATA needs twbxless to be accessible from the internet. Run twbxless from some serverless somewhere,
-e.g. Google Cloud Run, Azure Containers, AWS, or Heroku, instead of on your computer.
+**PORT**: the port to bind to (default is `8080`)
 
-## Alternative build/run steps
+## Building/running outside container (optional, not recommended)
 
-If you want to dev/build/run outside a container, here are partial instructions e.g. for Windows:
+If you want to dev/build/run outside a container, here are partial steps e.g. for Windows:
 
 - provide JDK 14 and gradle
 - [download Hyper API](https://tableau.com/support/releases/hyper-api/latest)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ name,filename
 Hoja1 (genderOverall),Data/Fuentes de datos/Hoja1 (genderOverall).hyper
 ```
 
-Then use the `/data` endpoint, with the same `url`, adding `name`:
+Then use twbxless' `/data` URL,leaving `url` the same, adding `name`:
 
 ```
 http://localhost:8080/data?url=https://public.tableau.com/workbooks/FemaleDirectors.twb&name=Hoja1 (genderOverall)
@@ -78,7 +78,7 @@ Total,2003,female,16,0.076,0
 ...
 ```
 
-URLs like this last `/data` one could be used in any tool that works with CSV URLs, for example Excel's "Get Data From Web", even Tableau itself!
+URLs like this last `/data` URL could be used in any tool that works with CSV URLs, for example Excel's "Get Data From Web", or even Tableau itself if you have a CSV data connector.
 
 ## Frequently asked questions
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,11 @@ that may require [a CSV web data connector](https://help.tableau.com/current/pro
 
 To build twbxless as a container, provide
 [Docker](https://hub.docker.com/search?q=&type=edition&offering=community&sort=updated_at&order=desc)
-then `docker build . -t twbxless`.
+then run
+
+```
+docker build . -t twbxless
+```
 
 ## Run
 
@@ -29,7 +33,7 @@ You should see
 2020-05-14 23:39:50.695  INFO 1 --- [main] com.rationalagents.twbxless.Application     : Starting Application
 ```
 
-indicating it's running, and you're ready to move onto **Use.**
+If so, you're ready to move on to **Use.**
 
 Ctrl+C will stop the container once you're done with it.
 

--- a/README.md
+++ b/README.md
@@ -1,48 +1,37 @@
 # twbxless
-*twbxless* makes data exported in Tableau packaged workbook files (.twbx) available at CSV URLs for other tools, 
-e.g. Excel data models or Google Sheets IMPORTDATA. This is possible thanks to 
+
+*twbxless* makes data exported in Tableau packaged workbook files (.twbx) available at CSV URLs for other tools,
+e.g. Excel data models or Google Sheets IMPORTDATA. This is possible thanks to
 [Tableau's Hyper API](https://help.tableau.com/current/api/hyper_api/en-us/index.html).
 
-It's possibly also useful for sustaining a community of Tableau visualization riffs, where creators make new 
-public workbooks from data exported to other workbooks, rather than having to copy those workbooks and deal 
-with new copies to get new data. [Let us know how we can improve it!](/../../issues) Using twbxless for 
+It's possibly also useful for sustaining a community of Tableau visualization riffs, where creators make new
+public workbooks from data exported to other workbooks, rather than having to copy those workbooks and deal
+with new copies to get new data. [Let us know how we can improve it!](/../../issues) Using twbxless for
 that may require [a CSV web data connector](https://help.tableau.com/current/pro/desktop/en-us/examples_web_data_connector.htm).
 
 ## Build
 
-To build twbxless as a container, provide 
+To build twbxless as a container, provide
 [Docker](https://hub.docker.com/search?q=&type=edition&offering=community&sort=updated_at&order=desc)
 then `docker build . -t twbxless`.
 
-If you want to dev/build outside a container,
- - provide JDK 14 and gradle
- - [download Hyper API for Java](https://tableau.com/support/releases/hyper-api/latest)
- - extract *lib* from the Hyper API for Java package and put it along side *src*
- - `gradle build`
-
 ## Run
 
-After building the container, run
+After building, run
 
 ```
 docker run -it -p8080:8080 twbxless:latest
 ```
 
-and you should see output like:
+You should see
 
 ```
 2020-05-14 23:39:50.695  INFO 1 --- [main] com.rationalagents.twbxless.Application     : Starting Application
 ```
 
-That means it's running, and you're ready to move onto **Use.** You can Ctrl+C to stop.
+indicating it's running, and you're ready to move onto **Use.**
 
-If you're thinking "yeah, I already did hard way once, `gradle build`, it definitely built, let me keep on this 
-so-called hard way, and I'm on Windows, so whatcha got for me dawg", do something like this:
-
-```
-set HYPEREXEC=lib\hyper
-java -jar build/libs/twbxless.jar
-```
+Ctrl+C will stop the container once you're done with it.
 
 ## Config (optional)
 
@@ -54,14 +43,13 @@ twbxless supports 3 configuration environment variables:
 
 **URLPREFIX**: required prefix for any URL retrieved (default is `https://public.tableau.com/`)
 
-
 ## Use
 
-First you'll need to identify the data extracts within a .twbx that's published on the web. To do that, 
+First you'll need to identify the data extracts within a .twbx that's published on the web. To do that,
 use the `/filenames` endpoint, specifying the `url` to the workbook.
 
 For example, for [this workbook featured on Viz of the Day](https://public.tableau.com/profile/maximiliano4575#!/vizhome/FemaleDirectors/FemaleDirectors)
-, the `url` we need's the one backing Tableau Public's "Download" button. Use `/filenames` with that `url`: 
+, the `url` we need's the one backing Tableau Public's "Download" button. Use `/filenames` with that `url`:
 
 ```
 http://localhost:8080/filenames?url=https://public.tableau.com/workbooks/FemaleDirectors.twb
@@ -96,8 +84,8 @@ Total,2003,female,16,0.076,0
 
 ## Enhancements & limitations
 
-- This doesn't support all column types, for example geography. It'll include unsupported columns in the CSV, but 
-non-null values will be `TYPE?`. Please [file an issue with an example workbook](/../../issues) if you'd like support
+- This doesn't support all column types, for example geography. Any unsupported column will appear in the CSV, but
+non-null values in the column will be `TYPE?`. Please [file an issue with an example workbook](/../../issues) if you'd like support
 for a particular type.
 - Only supports single schema & table per .hyper file. I've seen plenty of workbooks with multiple .hyper files (one per
 data source), but never a workbook where there was >1 schema/table in a file.  If you need this
@@ -108,13 +96,22 @@ know which file has the data you want! It'd be nice to improve on that. If inter
 
 ## FAQ
 
-#### Does twbxless provide access to the external data sources used to make a workbook?
+### Does twbxless provide access to the external data sources used to make a workbook?
 
 No. It only reads the data that's directly in the .twbx file.
 
-#### Does Google Sheets' IMPORTDATA work with http:<nolink>//localhost:8080 URLs?
+### Does Google Sheets' IMPORTDATA work with http:<nolink>//localhost:8080 URLs?
 
 No, Google Sheets IMPORTDATA needs twbxless to be accessible from the internet. Run twbxless from some serverless somewhere,
 e.g. Google Cloud Run, Azure Containers, AWS, or Heroku, instead of on your computer.
 
+## Alternative build/run steps
 
+If you want to dev/build/run outside a container, here are partial instructions e.g. for Windows:
+
+- provide JDK 14 and gradle
+- [download Hyper API](https://tableau.com/support/releases/hyper-api/latest)
+- extract *lib* from the Hyper API package and put it along side *src*
+- `gradle build`
+- `set HYPEREXEC=lib\hyper`
+- `java -jar build/libs/twbxless.jar`

--- a/README.md
+++ b/README.md
@@ -84,7 +84,11 @@ URLs like this last `/data` URL could be used in any tool that works with CSV UR
 
 ### Does twbxless provide access to the external data sources used to make a workbook?
 
-No. twbxless only reads data that's stored within the .twbx/.hyper files, data that can be viewed in Tableau desktop by anyone who downloads the .twbx file.
+No, twbxless only reads data that's extracted, stored within .twbx files.
+
+### How often can I get fresh data?
+
+Because twbxless only reads the data extracted into the .twbx file, the publisher of the workbook would need to refresh the extract first using Tableau. For example see [How to Keep Data Fresh](https://help.tableau.com/current/online/en-us/to_keep_data_fresh.htm).
 
 ### Does Google Sheets' IMPORTDATA work with http://localhost:8080 URLs like the ones in the examples?
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # twbxless
 
 *twbxless* makes data exported in Tableau packaged workbook files (.twbx) available at CSV URLs for other tools,
-e.g. Excel data models or Google Sheets IMPORTDATA. This is possible thanks to
-[Tableau's Hyper API](https://help.tableau.com/current/api/hyper_api/en-us/index.html).
+e.g. Excel data models or Google Sheets IMPORTDATA. This is possible thanks to Tableau's
+[Hyper API](https://help.tableau.com/current/api/hyper_api/en-us/index.html).
 
-It's possibly also useful for sustaining a community of Tableau visualization riffs, where creators make new
-public workbooks from data exported to other workbooks, rather than having to copy those workbooks and deal
-with new copies to get new data. [Let us know how we can improve it!](/../../issues) Using twbxless for
-that may require [a CSV web data connector](https://help.tableau.com/current/pro/desktop/en-us/examples_web_data_connector.htm).
+It's possibly also useful for sustaining a community of Tableau visualization makers, where new workbooks are made from data available only through other workbooks/twbxless. Using twbxless as a data source in Tableau may require [a CSV web data connector](https://help.tableau.com/current/pro/desktop/en-us/examples_web_data_connector.htm).
+
+[Let us know how we can make twbxless better](/../../issues)!
 
 ## Build
 

--- a/README.md
+++ b/README.md
@@ -39,34 +39,33 @@ Ctrl+C will stop the container once you're done with it.
 
 ## Use
 
-First you'll need to identify the data extracts within a .twbx that's published on the web. To do that,
-use the `/datasources` endpoint, specifying the `url` to the workbook.
+First you'll need to determine the URL of a Tableau workbook (.twbx file) published on the web.
 
-For example, for [this workbook featured on Viz of the Day](https://public.tableau.com/profile/maximiliano4575#!/vizhome/FemaleDirectors/FemaleDirectors)
-, the `url` we need's the one your web browser navaigates to when you click Tableau Public's "Download" button. 
+For example, [for this workbook featured on Viz of the Day](https://public.tableau.com/profile/maximiliano4575#!/vizhome/FemaleDirectors/FemaleDirectors)
+the `url` needed is the one the browser navigates to (downloading the file) when you click Tableau Public's "Download" button: <https://public.tableau.com/workbooks/FemaleDirectors.twb>.
 
-Use `/datasources` with that `url`:
+Compose that `url` together with twbxless' `/datasources` URL to list the data source extracts in the workbook:
 
 ```
 http://localhost:8080/datasources?url=https://public.tableau.com/workbooks/FemaleDirectors.twb
 ```
 
-and you'll get a list of datasource names (and .hyper filenames) within that workbook, in CSV format. 
+You get a list of data source names (and corresponding extract filenames) within the workbook, in CSV format.
 
-There's just 1 data source in *FemaleDirectors.twb*, named "Hoja1 (genderOverall)":
+There's just 1 data source in *FemaleDirectors.twb*, named *Hoja1 (genderOverall)*:
 
 ```
 name,filename
 Hoja1 (genderOverall),Data/Fuentes de datos/Hoja1 (genderOverall).hyper
 ```
 
-Then switch to the `/data` endpoint, using the same `url`, and specifying the data source `name`:
+Then use the `/data` endpoint, with the same `url`, adding `name`:
 
 ```
 http://localhost:8080/data?url=https://public.tableau.com/workbooks/FemaleDirectors.twb&name=Hoja1 (genderOverall)
 ```
 
-and you'll get back the row/column data from that data source, in CSV format:
+You get back the row/column data from that data source, in CSV format:
 
 ```
 genre,year,gender,freq,percent,filter
@@ -80,17 +79,18 @@ Total,2003,female,16,0.076,0
 ...
 ```
 
-## Use FAQs
+URLs like this last `/data` one could be used in any tool that works with CSV URLs, for example Excel's "Get Data From Web", even Tableau itself!
+
+## Frequently asked questions
 
 ### Does twbxless provide access to the external data sources used to make a workbook?
 
-No. twbxless only reads the data that's stored within the .twbx/.hyper files, data that can be viewed in Tableau desktop
-by anyone who downloads the .twbx file.
+No. twbxless only reads data that's stored within the .twbx/.hyper files, data that can be viewed in Tableau desktop by anyone who downloads the .twbx file.
 
-### Does Google Sheets' IMPORTDATA work with http:<nolink>//localhost:8080 URLs?
+### Does Google Sheets' IMPORTDATA work with http://localhost:8080 URLs like the ones in the examples?
 
-No, Google Sheets IMPORTDATA needs twbxless to be accessible from the internet. Run twbxless from some serverless somewhere,
-e.g. Google Cloud Run, Azure Containers, AWS, or Heroku, instead of on your computer.
+No, unfortunately Google Sheets IMPORTDATA URLs need to be accessible from the internet. Run twbxless from a cloud container host,
+e.g. Google Cloud Run, Azure Containers, or AWS ECS, instead of on your computer, if you need to use it with Google Sheets.
 
 ## Limitations
 
@@ -103,13 +103,13 @@ data source), but never a workbook where there was more than one schema/table in
 
 ## Configuration (optional)
 
-twbxless supports 3 configuration environment variables.
+twbxless supports 3 configuration environment variables
 
-**URLPREFIX**: required prefix for any URL retrieved (default is `https://public.tableau.com/`)
-
-**HYPEREXEC**: path to the executables (e.g. hyperd or hyperd.exe) packaged with Hyper API (default is `/hyperapi/lib/hyper` since that's where [Dockerfile](Dockerfile) puts them)
-
-**PORT**: the port to bind to (default is `8080`)
+> **URLPREFIX**: required prefix for any URL retrieved (default is `https://public.tableau.com/`)
+>
+> **HYPEREXEC**: path to the executables (e.g. hyperd or hyperd.exe) packaged with Hyper API (default is `/hyperapi/lib/hyper` since that's where [Dockerfile](Dockerfile) puts them)
+>
+> **PORT**: the port to bind to (default is `8080`)
 
 ## Building/running outside container (optional, not recommended)
 

--- a/README.md
+++ b/README.md
@@ -86,17 +86,14 @@ No. It only reads the data that's directly in the .twbx file.
 No, Google Sheets IMPORTDATA needs twbxless to be accessible from the internet. Run twbxless from some serverless somewhere,
 e.g. Google Cloud Run, Azure Containers, AWS, or Heroku, instead of on your computer.
 
-## Enhancements & limitations
+## Limitations
 
 - This doesn't support all column types, for example geography. Any unsupported column will appear in the CSV, but
 non-null values in the column will be `TYPE?`. Please [file an issue with an example workbook](/../../issues) if you'd like support
 for a particular type.
 - Only supports single schema & table per .hyper file. I've seen plenty of workbooks with multiple .hyper files (one per
 data source), but never a workbook where there was >1 schema/table in a file.  If you need this
-[please provide an example workbook for enhancement #4](/../../issues/4).
-- Unfortunately the .hyper filenames within .twbx files are rather opaque. Even after trying `/filenames` you might not
-know which file has the data you want! It'd be nice to improve on that. If interested please
-[stop by enhancement #7](/../../issues/7).
+[please provide an example workbook](/../../issues/4).
 
 ## Configuring twbxless (optional)
 

--- a/README.md
+++ b/README.md
@@ -40,29 +40,33 @@ Ctrl+C will stop the container once you're done with it.
 ## Use
 
 First you'll need to identify the data extracts within a .twbx that's published on the web. To do that,
-use the `/filenames` endpoint, specifying the `url` to the workbook.
+use the `/datasources` endpoint, specifying the `url` to the workbook.
 
 For example, for [this workbook featured on Viz of the Day](https://public.tableau.com/profile/maximiliano4575#!/vizhome/FemaleDirectors/FemaleDirectors)
-, the `url` we need's the one backing Tableau Public's "Download" button. Use `/filenames` with that `url`:
+, the `url` we need's the one your web browser navaigates to when you click Tableau Public's "Download" button. 
+
+Use `/datasources` with that `url`:
 
 ```
-http://localhost:8080/filenames?url=https://public.tableau.com/workbooks/FemaleDirectors.twb
+http://localhost:8080/datasources?url=https://public.tableau.com/workbooks/FemaleDirectors.twb
 ```
 
-and in CSV format you get a list of .hyper extract filenames within that workbook (there's just 1 in *FemaleDirectors.twb*):
+and you'll get a list of datasource names (and .hyper filenames) within that workbook, in CSV format. 
+
+There's just 1 data source in *FemaleDirectors.twb*, named "Hoja1 (genderOverall)":
 
 ```
-filenames
-Data/Fuentes de datos/Hoja1 (genderOverall).hyper
+name,filename
+Hoja1 (genderOverall),Data/Fuentes de datos/Hoja1 (genderOverall).hyper
 ```
 
-Then we switch to the `/data` endpoint, using the same `url`, adding `filename`:
+Then switch to the `/data` endpoint, using the same `url`, and specifying the data source `name`:
 
 ```
-http://localhost:8080/data?url=https://public.tableau.com/workbooks/FemaleDirectors.twb&filename=Data/Fuentes de datos/Hoja1 (genderOverall).hyper
+http://localhost:8080/data?url=https://public.tableau.com/workbooks/FemaleDirectors.twb&name=Hoja1 (genderOverall)
 ```
 
-and we get the data from that file
+and you'll get back the row/column data from that data source, in CSV format:
 
 ```
 genre,year,gender,freq,percent,filter
@@ -75,11 +79,13 @@ Total,2002,male,201,0.931,0
 Total,2003,female,16,0.076,0
 ...
 ```
-## FAQ
+
+## Use FAQs
 
 ### Does twbxless provide access to the external data sources used to make a workbook?
 
-No. It only reads the data that's directly in the .twbx file.
+No. twbxless only reads the data that's stored within the .twbx/.hyper files, data that can be viewed in Tableau desktop
+by anyone who downloads the .twbx file.
 
 ### Does Google Sheets' IMPORTDATA work with http:<nolink>//localhost:8080 URLs?
 
@@ -88,14 +94,14 @@ e.g. Google Cloud Run, Azure Containers, AWS, or Heroku, instead of on your comp
 
 ## Limitations
 
-- This doesn't support all column types, for example geography. Any unsupported column will appear in the CSV, but
-non-null values in the column will be `TYPE?`. Please [file an issue with an example workbook](/../../issues) if you'd like support
-for a particular type.
-- Only supports single schema & table per .hyper file. I've seen plenty of workbooks with multiple .hyper files (one per
-data source), but never a workbook where there was >1 schema/table in a file.  If you need this
+- twbxless doesn't support all column types, for example geography. Unsupported columns will appear in the `/data` response, but
+non-null values in those columns appear as `TYPE?`. Please [file an issue with an example workbook](/../../issues) if you'd like
+support for a particular type.
+- twbxless supports a single schema & table per .hyper file. I've seen plenty of workbooks with multiple .hyper files (one per
+data source), but never a workbook where there was more than one schema/table in the file. If you need this
 [please provide an example workbook](/../../issues/4).
 
-## Configuring twbxless (optional)
+## Configuration (optional)
 
 twbxless supports 3 configuration environment variables.
 


### PR DESCRIPTION
README.md now no longer explains the harder-to use /filenames and /data?filename endpoints. I also reorganized readme to put optional things toward the end, rather than in the flow of build/run/use, and removed an enhancement mentioned that's already been done.